### PR TITLE
Proper handling for input files not ending in newlines.

### DIFF
--- a/src/modules/convert-csv-to-array-of-arrays.js
+++ b/src/modules/convert-csv-to-array-of-arrays.js
@@ -3,17 +3,17 @@ import { convertStringToNumber } from 'convert-string-to-number';
 export const convertCSVToArrayOfArrays = (data, { header, separator }) => {
   const csv = data;
   const array = [];
+
   const rows = csv.split(/(?!\B"[^"]*)\n(?![^"]*"\B)/g);
+  // remove the empty array that will be present at the end of rows if the input ended in a newline
+  if (csv.slice(-1) === '\n') rows.pop();
 
   rows.forEach((row, idx) => {
     const values = row.split(separator);
     const checkedAndConvertedValues = [];
     if (
-      rows.length - 1 !== idx
-      && (
-        (!header && idx !== 0)
-        || header
-      )
+      (!header && idx !== 0)
+      || header
     ) {
       values.forEach((value) => {
         const convertedToNumber = convertStringToNumber(value);

--- a/src/modules/convert-csv-to-array-of-objects.js
+++ b/src/modules/convert-csv-to-array-of-objects.js
@@ -3,6 +3,9 @@ import { convertStringToNumber } from 'convert-string-to-number';
 export const convertCSVToArrayOfObjects = (data, { header, separator }) => {
   const csv = data;
   const rows = csv.split(/(?!\B"[^"]*)\n(?![^"]*"\B)/g);
+  // remove the empty array that will be present at the end of rows if the input ended in a newline
+  if (csv.slice(-1) === '\n') rows.pop();
+
   const array = [];
 
   let headerRow;
@@ -20,7 +23,7 @@ export const convertCSVToArrayOfObjects = (data, { header, separator }) => {
           [headerItem]: undefined,
         });
       });
-    } else if (rows.length - 1 !== idx) {
+    } else {
       const values = row.split(separator);
 
       values.forEach((value, i) => {

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -5,3 +5,5 @@ export const dataHeaderSemicolonSeparated = 'number;first;last;handle\n1;Mark;Ot
 export const dataHeaderTabSeparated = 'number\tfirst\tlast\thandle\n1\tMark\tOtto\t@mdo\n2\tJacob\tThornton\t@fat\n3\tLarry\tthe Bird\t@twitter\n';
 
 export const dataWithMultilineEntries = 'number;first;last;handle\n1;Mark;"Ot\nto";@mdo\n2;Jacob;"Thor\nnton";@fat\n3;Larry;"the\nBird";@twitter\n';
+
+export const dataNotEndingInNewline = 'number,first,last,handle\n1,Mark,Otto,@mdo\n2,Jacob,Thornton,@fat\n3,Larry,the Bird,@twitter';

--- a/test/modules/convert-csv-to-array-of-arrays.spec.js
+++ b/test/modules/convert-csv-to-array-of-arrays.spec.js
@@ -4,6 +4,7 @@ import {
   dataHeaderSemicolonSeparated,
   dataHeaderTabSeparated,
   dataWithMultilineEntries,
+  dataNotEndingInNewline
 } from '../fixtures/data';
 import {
   expectedResultArrayHeader,
@@ -38,4 +39,10 @@ test('convertCSVToArrayOfArrays | line break in value', () => {
   const result = convertCSVToArrayOfArrays(dataWithMultilineEntries, { header: false, separator: ';' });
 
   expect(result).toEqual(expectedResultArrayMultiline);
+});
+
+test('convertCSVToArrayOfArrays | no ending newline in input', () => {
+  const result = convertCSVToArrayOfArrays(dataNotEndingInNewline, {header: true, separator: ','});
+
+  expect(result).toEqual(expectedResultArrayHeader);
 });

--- a/test/modules/convert-csv-to-array-of-objects.spec.js
+++ b/test/modules/convert-csv-to-array-of-objects.spec.js
@@ -4,6 +4,7 @@ import {
   dataHeaderSemicolonSeparated,
   dataHeaderTabSeparated,
   dataWithMultilineEntries,
+  dataNotEndingInNewline
 } from '../fixtures/data';
 import {
   expectedResultObjectHeader,
@@ -39,4 +40,10 @@ test('convertCSVToArrayOfObjects | line break in value', () => {
   const result = convertCSVToArrayOfObjects(dataWithMultilineEntries, { header: false, separator: ';' });
 
   expect(result).toEqual(expectedResultObjectMultiline);
+});
+
+test('convertCSVToArrayOfObjects | no ending newline in input', () => {
+  const result = convertCSVToArrayOfObjects(dataNotEndingInNewline, {header: true, separator: ','});
+
+  expect(result).toEqual(expectedResultObjectHeader);
 });


### PR DESCRIPTION
This PR solves #6.

The regex used to split the input CSV into an array of rows will add an extra empty string to the end of the array if the input CSV ends in `\n`. The code used to further process the array of rows assumes this will happen every time, and simply throws away the last row in the array. But if the input CSV did not end in a newline, then the last row in the split array will not be blank, and thus the last row in the CSV is not converted.

This revised code is modified to only throw away the last row of the array if the input CSV ended in a `\n`, so that every line of actual data is converted whether the input ended in a newline or not.

I also added a couple of new test cases to verify that input CSVs without newlines at the end are converted correctly.